### PR TITLE
Use WiFiManager

### DIFF
--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/web.cpp
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/web.cpp
@@ -31,6 +31,8 @@
 #include "settings.h"
 
 #include "wlan.h"
+#include <WiFiManager.h> // https://github.com/tzapu/WiFiManager
+
 extern uint8_t data_to_send[];
 
 AsyncWebServer server(80);
@@ -131,26 +133,14 @@ void WriteBMP(const char *filename, uint8_t *pData, int width, int height, int b
 
 void init_web()
 {
-  WiFi.mode(WIFI_AP_STA);
-  WiFi.begin(ssid, password);
-  WiFi.softAP("home", "aaaaaaaa");
-  if (WiFi.waitForConnectResult() != WL_CONNECTED)
-  {
-    WiFi.disconnect(false);
-    delay(1000);
-    WiFi.begin(ssid, password);
-  }
-  long start_wifi = millis();
-  while (WiFi.status() != WL_CONNECTED)
-  {
-    delay(500);
-    Serial.print(".");
-    if (millis() - start_wifi > 20000)
-      return;
-    if (WiFi.softAPgetStationNum() > 0)
-      return;
-  }
-  Serial.println("");
+  WiFi.mode(WIFI_STA);
+  WiFiManager wm;
+  bool res;
+  res = wm.autoConnect("AutoConnectAP");
+  if(!res) {
+      Serial.println("Failed to connect");
+      ESP.restart();
+  } 
   Serial.print("Connected! IP address: ");
   Serial.println(WiFi.localIP());
 

--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/wlan_gitignore_replacement.h
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/wlan_gitignore_replacement.h
@@ -1,5 +1,3 @@
 #pragma once
-const char* ssid = "xxx";
-const char* password = "xxx";
 const char* http_username = "admin";
 const char* http_password = "admin";

--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/platformio.ini
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/platformio.ini
@@ -16,6 +16,9 @@ framework = arduino
 lib_deps =
     bblanchon/ArduinoJson@^6.17.3
     me-no-dev/ESPAsyncWebServer
+    https://github.com/tzapu/WiFiManager.git#feature_asyncwebserver
+; esp32 support doesn't exist in release yet,
+; https://github.com/tzapu/WiFiManager/issues/1231#issuecomment-810598152
 
 [base:esp8266]
 monitor_speed = 500000

--- a/Custom_PriceTag_AccesPoint/README.md
+++ b/Custom_PriceTag_AccesPoint/README.md
@@ -13,9 +13,10 @@ It should work on more displays from the Company ZBD / DisplayData but these are
 
 This project is set up to use PlatformIO but it should also be possible to compile and flash using the Arduino IDE.
 * Connect the CC1101 868 MHz radio module to the ESP32 using the pinout specified [in the RFV3.h header file](ESP32_Async_PlatformIO/RFV3/RFV3.h).
-* Rename [wlan_gitignore_replacement.h](ESP32_Async_PlatformIO/RFV3/wlan_gitignore_replacement.h) to wlan.h and supply your WiFi credentials
+* Rename [wlan_gitignore_replacement.h](ESP32_Async_PlatformIO/RFV3/wlan_gitignore_replacement.h) to wlan.h and supply the desired credentials for the admin interface
 * Build the project and upload to the ESP32
-* Upon first boot, the ESP32 will connect to WiFi Navigate with a browser to *ip*/edit and upload the supplied [index.htm](ESP32_Async_PlatformIO/data/index.htm)
+* To set up the WLAN credentials, connect to the access point called "AutoConnectAP" and navigate to http://192.168.4.1 (you should be redirected there automatically). Click on the name of your network (SSID), enter your WLAN password, and click on "Save*. The ESP32 will restart and will connect to the selected WLAN. In case the selected WLAN is not available, the ESP32 will automatically open the access point called "AutoConnectAP", allowing you to select another WLAN ([details](https://github.com/tzapu/WiFiManager))
+* Navigate with a browser to *ip*/edit and upload the supplied [index.htm](ESP32_Async_PlatformIO/index.htm)
 * Normal control of the AccessPoint can now be controlled by navigating to the IP address of the ESP32
 
 ## Radio Module Quirks


### PR DESCRIPTION
This pull request removes the need to hardcode WLAN credentials in in a header file by using [WiFiManager](https://github.com/tzapu/WiFiManager/) (`feature_asyncwebserver` branch).

Apparently it also allows one to do OTA (over-the-air firmware updates), although I have not tested this yet.

It would also be possible to make additional parameters configurable through the WiFiManager, as explained [here](https://randomnerdtutorials.com/wifimanager-with-esp8266-autoconnect-custom-parameter-and-manage-your-ssid-and-password/).