### PR TITLE
Use last_compressed_img.bin as the default filename for "Send file from spiffs"

### DIFF
--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
@@ -75,7 +75,7 @@
             (First upload the files <a href="/edit">here</a>)
         </p>
         <label for="file">Filename:</label>
-        <input type="text" id="file" name="file" value="buffer.bin">
+        <input type="text" id="file" name="file" value="last_compressed_img.bin">
         <button
             onclick='send("set_file?id="+document.getElementById("disp_id1").value+"&file="+document.getElementById("file").value)'>Send
             file from spiffs</button>


### PR DESCRIPTION
`last_compressed_img.bin` is the name of the file that gets stored on SPIFFS when clicking "send .bmp and save compressed one on spiffs", so this makes the operation easier.