### PR TITLE
Workaround for #34

### DIFF
--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
@@ -101,7 +101,7 @@
   </select>
   <br>
 <textarea id="multiline" name="multiline" rows="8" cols="32" wrap="hard">
-Enter text here. Each display type uses a font which fits about 18 characters per line. Press the 'Send Text' button above to transmit it.
+Enter text here. Each display type uses a font which fits about 18 characters per line.
 </textarea>
 
 <br>


### PR DESCRIPTION
Use shorter sample text that doesn't crash the ESP