### PR TITLE
separate fullsync and wu+fullsync modes

### DIFF
--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/web.cpp
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/web.cpp
@@ -523,10 +523,15 @@ void init_web()
         set_is_data_waiting(0);
         set_mode_idle();
       }
-      else if (new_mode == "sync")
+      else if (new_mode == "wusync")
       {
         set_is_data_waiting(0);
         set_mode_wu();
+      }
+      else if (new_mode == "fullsync")
+      {
+        set_is_data_waiting(0);
+        set_mode_full_sync();
       }
       else
       {

--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/data/index.htm
@@ -119,7 +119,8 @@ Enter text here. Each display type uses a font which fits about 18 characters pe
     <section>
         <h2>Maintenance</h2>
         <button onclick='get("heap")'>Get Heap</button>
-        <button onclick='send("set_mode?mode=sync")'>Do sync</button>
+        <button onclick='send("set_mode?mode=wusync")'>Wake + Full Sync</button>
+        <button onclick='send("set_mode?mode=fullsync")'>Full Sync</button>
         <button onclick='send("set_mode?mode=idle")'>Idle</button>
         <button onclick='send("delete_file")'>delete log files</button>
         <button onclick='send("reboot")'>Reboot ESP32</button>


### PR DESCRIPTION
This is kind of a breaking change, so decide if you want to merge it or maybe do something similar your own ;)
The `Do Sync` Button actually performs a Wake Up followed by a Full Sync. During testing I found it very helpful to be able to only use the Full Sync without Wake Up. So I separated the modes into two buttons. The old `Do Sync` is equivalent to `Wake + Full Sync`.
I considered keeping the name `sync` for the old mode, but I think it is kind of confusing.