### PR TITLE
Fixed line position in entropy calculation

### DIFF
--- a/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/arith.cpp
+++ b/Custom_PriceTag_AccesPoint/ESP32_Async_PlatformIO/RFV3/arith.cpp
@@ -213,7 +213,7 @@ void calculate_entropy(File file, uint8_t *pBitmap, image_s *bin_image_input, _b
             if (bmp_infos->bTopDown)
                 file.seek(bmp_infos->offset + (bmp_infos->pitch * current_x), SeekSet);
             else
-                file.seek(bmp_infos->offset + (bin_image_input->height - 1 - current_x) * bmp_infos->pitch, SeekSet);
+                file.seek(bmp_infos->offset + (bin_image_input->width - 1 - current_x) * bmp_infos->pitch, SeekSet);
             file.read(&bin_image_input->current_line[1], (size_t)bin_image_input->height / 8);
         }
 


### PR DESCRIPTION
Hi I was trying to port code to Linux and accidentally found found a bug in reading bitmap lines in entropy calculation function. Loop is iterating over `bin_image_input->width` here but the difference was made from  `bin_image_input->height` which is in case of Chroma29 lower. This caused attempts to seek negative position number. Seek function was seamlessly failing and position was set to 0, in fact.